### PR TITLE
Add LibPThread for ubuntu 14.04 compilation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,9 @@
+## General
 
 > make
 
 follow directions!
 
-Thanks!
+## Ubuntu dependencies
+
+freeglut3-dev libsndfile-dev libxi-dev libxmu-dev libgl-dev

--- a/src/sndpeek/makefile.alsa
+++ b/src/sndpeek/makefile.alsa
@@ -4,7 +4,7 @@ CPP=g++
 INCLUDES=-I../marsyas/
 MARSYAS_DIR=../marsyas/
 CFLAGS=-D__LINUX_ALSA__ -D__LITTLE_ENDIAN__ $(INCLUDES) -O3 -c
-LIBS=-L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile
+LIBS=-L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile -lpthread
 
 OBJS=chuck_fft.o RtAudio.o Thread.o sndpeek.o Stk.o \
 	Centroid.o DownSampler.o Flux.o LPC.o MFCC.o RMS.o Rolloff.o \


### PR DESCRIPTION
Fixes the following error

```
g++ -o sndpeek chuck_fft.o RtAudio.o Thread.o sndpeek.o Stk.o Centroid.o DownSampler.o Flux.o LPC.o MFCC.o RMS.o Rolloff.o System.o fvec.o AutoCorrelation.o Communicator.o Hamming.o MagFFT.o NormRMS.o MarSignal.o fmatrix.o -L/usr/X11R6/lib -lglut -lGL -lGLU -lasound -lXmu -lX11 -lXext -lXi -lm -lsndfile 
/usr/bin/ld: Thread.o: undefined reference to symbol 'pthread_cancel@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
makefile.alsa:15: recipe for target 'sndpeek' failed
make[1]: *** [sndpeek] Error 1
make[1]: Leaving directory '~/whistle/sndpeek/src/sndpeek'
makefile:20: recipe for target 'linux-alsa' failed
make: [linux-alsa] Error 2 (ignored)
```
